### PR TITLE
fix: correct spelling in contact actions comment

### DIFF
--- a/src/actions/contactActions.js
+++ b/src/actions/contactActions.js
@@ -3,7 +3,7 @@ import { RestDBAxios } from '../index.js';
 /*
  * Account, Contacts, Opportunities will all follow the same structure
  * With there being 3 functions that will be run
- * Request --> Fetch --> Recieved
+ * Request --> Fetch --> Received
  * This follows a convention stated under Async Actions in Redux:
  *
  * https://redux.js.org/advanced/async-actions


### PR DESCRIPTION
## Summary
- fix typo in contact actions comment

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_68adb211f29c8327a5d0693a7e7e7ce4